### PR TITLE
Add stroke on touch and move callhistorychanged

### DIFF
--- a/lib/src/draw.dart
+++ b/lib/src/draw.dart
@@ -148,7 +148,6 @@ class _DrawState extends State<Draw> {
       ),
     );
     _redoStack.clear();
-    _callHistoryChanged();
   }
 
   void _add(double x, double y) {
@@ -163,16 +162,30 @@ class _DrawState extends State<Draw> {
       height: double.infinity,
       width: double.infinity,
       child: GestureDetector(
-        onPanStart: (details) => _start(
-          details.localPosition.dx,
-          details.localPosition.dy,
-        ),
+        onTapUp: (details) {
+          _start(
+            details.localPosition.dx,
+            details.localPosition.dy,
+          );
+          _add(
+            details.localPosition.dx,
+            details.localPosition.dy,
+          );
+          _callHistoryChanged();
+        },
+        onPanStart: (details) {
+          _start(
+            details.localPosition.dx,
+            details.localPosition.dy,
+          );
+        },
         onPanUpdate: (details) {
           _add(
             details.localPosition.dx,
             details.localPosition.dy,
           );
         },
+        onPanEnd: (_) => _callHistoryChanged(),
         child: LayoutBuilder(
           builder: (context, constraints) {
             _canvasSize = Size(constraints.maxWidth, constraints.maxHeight);


### PR DESCRIPTION
Hi, I found this package awesome, thank you for creating it 🤗
I've found some issues that I needed to fix for my project:
- canvas doesn't register stroke on touch, only when I drag my finger will the stroke be registered, this means I cannot just tap the canvas to draw a dot => I added a stroke on the `onTapDown` callback of the existing `GestureDetector`
- I wanted to call `convertToPng()` every time the drawing changed in `onHistoryChanged` callback, but the time that this callback is called currently doesn't allow for that (at the start of a stroke instead of when the stroke is finished => I moved it to places where a stroke is finished i.e. after adding a stroke in `onTapDown' and after the user has finished dragging their finger and lift the finger in `onPanEnd`. This doesn't alter the existing meaning of this callback and the two booleans that it provides.